### PR TITLE
[WIP] Add S3 analytics provider

### DIFF
--- a/local_analytics_provider.py
+++ b/local_analytics_provider.py
@@ -1,19 +1,16 @@
 from flask_babel import lazy_gettext as _
-from model import (
-    Session,
-    CirculationEvent,
-    ExternalIntegration,
-    get_one,
-    create
+from model import CirculationEvent, ExternalIntegration, Session, create, get_one
+
+from .model.configuration import (
+    ConfigurationAttributeType,
+    ConfigurationGrouping,
+    ConfigurationMetadata,
+    ConfigurationOption,
 )
 
-class LocalAnalyticsProvider(object):
-    NAME = _("Local Analytics")
 
-    DESCRIPTION = _("Store analytics events in the 'circulationevents' database table.")
-
-    # A given site can only have one analytics provider.
-    CARDINALITY = 1
+class LocalAnalyticsProviderConfiguration(ConfigurationGrouping):
+    """Contains configuration settings of the analytics provider."""
 
     # Where to get the 'location' of an analytics event.
     LOCATION_SOURCE = "location_source"
@@ -25,60 +22,181 @@ class LocalAnalyticsProvider(object):
     # Analytics events have no 'location'.
     LOCATION_SOURCE_DISABLED = ""
 
-    SETTINGS = [
-        {
-            "key": LOCATION_SOURCE,
-            "label": _("Geographic location of events"),
-            "description": _("Local analytics events may have a geographic location associated with them. How should the location be determined?<p>Note: to use the patron's neighborhood as the event location, you must also tell your patron authentication mechanism how to <i>gather</i> a patron's neighborhood information."),
-            "default": LOCATION_SOURCE_DISABLED,
-            "type": "select",
-            "options": [
-                { "key": LOCATION_SOURCE_DISABLED, "label": _("Disable this feature.") },
-                { "key": LOCATION_SOURCE_NEIGHBORHOOD, "label": _("Use the patron's neighborhood as the event location.") },
-            ],
-        },
-    ]
+    location_source = ConfigurationMetadata(
+        key=LOCATION_SOURCE,
+        label=_("Geographic location of events"),
+        description=_(
+            "Local analytics events may have a geographic location associated with them. "
+            "How should the location be determined?"
+            "<p>Note: to use the patron's neighborhood as the event location, "
+            "you must also tell your patron authentication mechanism how "
+            "to <i>gather</i> a patron's neighborhood information.</p>"
+        ),
+        type=ConfigurationAttributeType.SELECT,
+        required=True,
+        default=LOCATION_SOURCE_DISABLED,
+        options=[
+            ConfigurationOption(LOCATION_SOURCE_DISABLED, _("Disable this feature.")),
+            ConfigurationOption(
+                LOCATION_SOURCE_NEIGHBORHOOD,
+                _("Use the patron's neighborhood as the event location."),
+            ),
+        ],
+    )
+
+
+class LocalAnalyticsProvider(object):
+    """Base analytics provider."""
+
+    NAME = _("Local Analytics")
+
+    DESCRIPTION = _("Store analytics events in the 'circulationevents' database table.")
+
+    # A given site can only have one analytics provider.
+    CARDINALITY = 1
+
+    SETTINGS = LocalAnalyticsProviderConfiguration.to_settings()
 
     def __init__(self, integration, library=None):
         self.integration_id = integration.id
-        self.location_source = integration.setting(
-            self.LOCATION_SOURCE
-        ).value or self.LOCATION_SOURCE_DISABLED
+        self.location_source = (
+            integration.setting(
+                LocalAnalyticsProviderConfiguration.LOCATION_SOURCE
+            ).value
+            or LocalAnalyticsProviderConfiguration.LOCATION_SOURCE_DISABLED
+        )
         if library:
             self.library_id = library.id
         else:
             self.library_id = None
 
-    def collect_event(self, library, license_pool, event_type, time,
-        old_value=None, new_value=None, **kwargs):
+    def _collect_event(
+        self,
+        db,
+        library,
+        license_pool,
+        event_type,
+        time,
+        neighborhood,
+        old_value=None,
+        new_value=None,
+    ):
+        """Log the event using the appropriate for the specific provider's mechanism.
+
+        NOTE: This method may be overridden in child classes.
+
+        :param db: Database session
+        :type db: sqlalchemy.orm.session.Session
+
+        :param library: Library associated with the event
+        :type library: core.model.library.Library
+
+        :param license_pool: License pool associated with the event
+        :type license_pool: core.model.licensing.LicensePool
+
+        :param event_type: Type of the event
+        :type event_type: str
+
+        :param time: Event's timestamp
+        :type time: datetime.datetime
+
+        :param neighborhood: Geographic location of the event
+        :type neighborhood: str
+
+        :param old_value: Old value of the metric changed by the event
+        :type old_value: Any
+
+        :param new_value: New value of the metric changed by the event
+        :type new_value: Any
+
+        :return: 2-tuple containing a CirculationEvent object and a boolean value indicating
+            whether it's been created or was loaded from the database
+        :rtype: Tuple[CirculationEvent, bool]
+        """
+        return CirculationEvent.log(
+            db,
+            license_pool,
+            event_type,
+            old_value,
+            new_value,
+            start=time,
+            library=library,
+            location=neighborhood,
+        )
+
+    def collect_event(
+        self,
+        library,
+        license_pool,
+        event_type,
+        time,
+        old_value=None,
+        new_value=None,
+        **kwargs
+    ):
+        """Log the event using the appropriate for the specific provider's mechanism.
+
+        :param library: Library associated with the event
+        :type library: core.model.library.Library
+
+        :param license_pool: License pool associated with the event
+        :type Optional[license_pool]: core.model.licensing.LicensePool
+
+        :param event_type: Type of the event
+        :type event_type: str
+
+        :param time: Event's timestamp
+        :type time: datetime.datetime
+
+        :param old_value: Old value of the metric changed by the event
+        :type old_value: Any
+
+        :param new_value: New value of the metric changed by the event
+        :type new_value: Any
+
+        :param kwargs:
+
+        :return: 2-tuple containing a CirculationEvent object and a boolean value indicating
+            whether it's been created or was loaded from the database
+        :rtype: Tuple[CirculationEvent, bool]
+        """
         if not library and not license_pool:
             raise ValueError("Either library or license_pool must be provided.")
         if library:
-            _db = Session.object_session(library)
+            db = Session.object_session(library)
         else:
-            _db = Session.object_session(license_pool)
+            db = Session.object_session(license_pool)
         if library and self.library_id and library.id != self.library_id:
             return
 
         neighborhood = None
-        if self.location_source == self.LOCATION_SOURCE_NEIGHBORHOOD:
+        if (
+            self.location_source
+            == LocalAnalyticsProviderConfiguration.LOCATION_SOURCE_NEIGHBORHOOD
+        ):
             neighborhood = kwargs.pop("neighborhood", None)
 
-        return CirculationEvent.log(
-            _db, license_pool, event_type, old_value, new_value, start=time,
-            library=library, location=neighborhood
+        return self._collect_event(
+            db,
+            library,
+            license_pool,
+            event_type,
+            time,
+            neighborhood,
+            old_value,
+            new_value,
         )
 
     @classmethod
     def initialize(cls, _db):
-        """Find or create a local analytics service.
-        """
+        """Find or create a local analytics service."""
 
         # If a local analytics service already exists, return it.
         local_analytics = get_one(
-            _db, ExternalIntegration,
+            _db,
+            ExternalIntegration,
             protocol=cls.__module__,
-            goal=ExternalIntegration.ANALYTICS_GOAL
+            goal=ExternalIntegration.ANALYTICS_GOAL,
         )
 
         # If a local analytics service already exists, don't create a
@@ -86,11 +204,13 @@ class LocalAnalyticsProvider(object):
         # "Local Analytics".
         if not local_analytics:
             local_analytics, ignore = create(
-                _db, ExternalIntegration,
+                _db,
+                ExternalIntegration,
                 protocol=cls.__module__,
                 goal=ExternalIntegration.ANALYTICS_GOAL,
-                name=str(cls.NAME)
+                name=str(cls.NAME),
             )
         return local_analytics
+
 
 Provider = LocalAnalyticsProvider

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -41,6 +41,7 @@ class ExternalIntegrationLink(Base, HasFullTableCache):
     PROTECTED_ACCESS_BOOKS_KEY = '{0}_integration_id'.format(PROTECTED_ACCESS_BOOKS)
 
     MARC = "MARC_mirror"
+    ANALYTICS = "Analytics_mirror"
 
     id = Column(Integer, primary_key=True)
     external_integration_id = Column(

--- a/model/constants.py
+++ b/model/constants.py
@@ -239,6 +239,7 @@ class MediaTypes(object):
     AUDIOBOOK_MANIFEST_MEDIA_TYPE = u"application/audiobook+json"
     AUDIOBOOK_PACKAGE_MEDIA_TYPE = u"application/audiobook+zip"
     MARC_MEDIA_TYPE = u"application/marc"
+    JSON_MEDIA_TYPE = u"application/json"
 
     # To distinguish internally between Overdrive's audiobook and
     # (hopefully future) ebook manifests, we invent values for the

--- a/tests/test_local_analytics_provider.py
+++ b/tests/test_local_analytics_provider.py
@@ -1,12 +1,14 @@
-import pytest
-from ..testing import DatabaseTest
-from ..local_analytics_provider import LocalAnalyticsProvider
-from ..model import (
-    CirculationEvent,
-    ExternalIntegration,
-    create,
-)
 import datetime
+
+import pytest
+
+from ..local_analytics_provider import (
+    LocalAnalyticsProvider,
+    LocalAnalyticsProviderConfiguration,
+)
+from ..model import CirculationEvent, ExternalIntegration, create
+from ..testing import DatabaseTest
+
 
 class TestLocalAnalyticsProvider(DatabaseTest):
 
@@ -97,8 +99,8 @@ class TestLocalAnalyticsProvider(DatabaseTest):
         # neighborhood as the event location.
 
         p = LocalAnalyticsProvider
-        self.integration.setting(p.LOCATION_SOURCE).value = (
-            p.LOCATION_SOURCE_NEIGHBORHOOD
+        self.integration.setting(LocalAnalyticsProviderConfiguration.LOCATION_SOURCE).value = (
+            LocalAnalyticsProviderConfiguration.LOCATION_SOURCE_NEIGHBORHOOD
         )
         la = p(self.integration, self._default_library)
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds changes required by the new S3 analytics functionality implemented in [circulation/PR # 16](https://github.com/lyrasis/simplye-circulation/pull/16):
* new constants in `ExternalIntegrationLink` and `MediaTypes`
* `analytics_bucket` to `S3UploaderConfiguration` that should allow CM admins to set up buckets for storing analytics data in the admin UI
* changes in `LocalAnalyticsProviderConfiguration` allowing to reuse the logic determining event's location source.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
